### PR TITLE
Update Contributing guideline for appengine plugins repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+This project is currently stable, and we are primarily focused on critical bug fixes and platform evolution to ensure it continues to work for its supported use cases.
+
 Please follow the guidelines below before opening an issue or a PR:
 
 1. Ensure the issue was not already reported.


### PR DESCRIPTION
Following https://github.com/GoogleContainerTools/jib/blob/master/CONTRIBUTING.md
