### PR TITLE
Adding a new runtimeID java25 to prepare the next GAE Java release for JDK25 support.

### DIFF
--- a/appengine-plugins-core/src/main/java/com/google/cloud/tools/appengine/operations/AppYamlProjectStaging.java
+++ b/appengine-plugins-core/src/main/java/com/google/cloud/tools/appengine/operations/AppYamlProjectStaging.java
@@ -46,7 +46,7 @@ public class AppYamlProjectStaging {
   private static final String APP_YAML = "app.yaml";
 
   private static final ImmutableSet<String> GEN2_RUNTIMES =
-      ImmutableSet.of("java11", "java17", "java21");
+      ImmutableSet.of("java11", "java17", "java21", "java25");
 
   @VisibleForTesting
   static final ImmutableList<String> OTHER_YAMLS =

--- a/appengine-plugins-core/src/test/java/com/google/cloud/tools/appengine/operations/AppYamlProjectStagingTest.java
+++ b/appengine-plugins-core/src/test/java/com/google/cloud/tools/appengine/operations/AppYamlProjectStagingTest.java
@@ -124,7 +124,7 @@ public class AppYamlProjectStagingTest {
   public void testStageArchive_java25StandardPath() throws IOException, AppEngineException {
     stageArchive_gen2StandardPath("java25");
   }
-  
+
   private void stageArchive_gen2StandardPath(String runtime)
       throws IOException, AppEngineException {
     Files.write(
@@ -153,6 +153,11 @@ public class AppYamlProjectStagingTest {
   @Test
   public void testStageArchive_java21StandardBinaryPath() throws IOException, AppEngineException {
     stageArchive_gen2StandardBinaryPath("java21");
+  }
+
+  @Test
+  public void testStageArchive_java25StandardBinaryPath() throws IOException, AppEngineException {
+    stageArchive_gen2StandardBinaryPath("java25");
   }
 
   private void stageArchive_gen2StandardBinaryPath(String runtime)
@@ -191,6 +196,11 @@ public class AppYamlProjectStagingTest {
   @Test
   public void testStageArchive_java21BinaryWithoutEntrypoint() throws IOException {
     stageArchive_gen2BinaryWithoutEntrypoint("java21");
+  }
+
+  @Test
+  public void testStageArchive_java25BinaryWithoutEntrypoint() throws IOException {
+    stageArchive_gen2BinaryWithoutEntrypoint("java25");
   }
 
   private void stageArchive_gen2BinaryWithoutEntrypoint(String runtime) throws IOException {

--- a/appengine-plugins-core/src/test/java/com/google/cloud/tools/appengine/operations/AppYamlProjectStagingTest.java
+++ b/appengine-plugins-core/src/test/java/com/google/cloud/tools/appengine/operations/AppYamlProjectStagingTest.java
@@ -1,4 +1,4 @@
-Add java25 to GEN2_RUNTIMES set, preparing the next GAE release./*
+/*
  * Copyright 2016 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/appengine-plugins-core/src/test/java/com/google/cloud/tools/appengine/operations/AppYamlProjectStagingTest.java
+++ b/appengine-plugins-core/src/test/java/com/google/cloud/tools/appengine/operations/AppYamlProjectStagingTest.java
@@ -1,4 +1,4 @@
-/*
+Add java25 to GEN2_RUNTIMES set, preparing the next GAE release./*
  * Copyright 2016 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -120,6 +120,11 @@ public class AppYamlProjectStagingTest {
     stageArchive_gen2StandardPath("java21");
   }
 
+  @Test
+  public void testStageArchive_java25StandardPath() throws IOException, AppEngineException {
+    stageArchive_gen2StandardPath("java25");
+  }
+  
   private void stageArchive_gen2StandardPath(String runtime)
       throws IOException, AppEngineException {
     Files.write(


### PR DESCRIPTION

Fixes https://github.com/GoogleCloudPlatform/appengine-plugins/issues/1045

